### PR TITLE
`Any` module for skipping type checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ cache: bundler
 before_install: gem install bundler
 script: bundle exec rspec
 rvm:
+  - 2.2.0
   - 2.2.5
   - 2.3.1
   - 2.4.0
+  - jruby-9.1.10.0
   - ruby-head
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
+# 0.1.2
+## Added
+* `Any` module for skipping type checks
+* Optional `camelize` argument to convert keys to camelBacks
+
+# 0.1.0
+## Fixed
+* Fix schema mutability issue
+## Changed
+* Change `schema` class method to `json_schema` due to compatibility issues with other gems.
+
 # 0.0.6
-* Add `build_schema` instance method that builds hash from the schema without serializing it to json.
+## Added
+* `build_schema` instance method that builds hash from the schema without serializing it to json.
+## Changed
 * Allow nil values by default.
 * Allow nested objects.
 
-# 0.1.0
-* Change `schema` class method to `json_schema` due to compatibility issues with other gems.
-* Fix schema mutability issue
+
+

--- a/lib/surrealist.rb
+++ b/lib/surrealist.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require_relative 'surrealist/class_methods'
-require_relative 'surrealist/instance_methods'
-require_relative 'surrealist/boolean'
-require_relative 'surrealist/utils'
+require 'surrealist/class_methods'
+require 'surrealist/instance_methods'
+require 'surrealist/boolean'
+require 'surrealist/any'
+require 'surrealist/utils'
 require 'json'
 
 # Main module that provides the +json_schema+ class method and +surrealize+ instance method.

--- a/lib/surrealist/any.rb
+++ b/lib/surrealist/any.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# A module for any type-checks.
+module Any; end

--- a/lib/surrealist/builder.rb
+++ b/lib/surrealist/builder.rb
@@ -117,6 +117,8 @@ module Surrealist
       #
       # @return [boolean]
       def type_check_passed?(value:, type:)
+        return true if type == Any
+
         if type == Boolean
           [true, false].include?(value)
         else

--- a/lib/surrealist/version.rb
+++ b/lib/surrealist/version.rb
@@ -2,5 +2,5 @@
 
 module Surrealist
   # Defines the version of Surrealist
-  VERSION = '0.1.0'
+  VERSION = '0.1.2'
 end

--- a/spec/surrealist_spec.rb
+++ b/spec/surrealist_spec.rb
@@ -9,6 +9,7 @@ class Baz
     {
       foo:    Integer,
       bar:    Array,
+      anything: Any,
       nested: {
         left_side:  String,
         right_side: Boolean,
@@ -24,6 +25,12 @@ class Baz
     [1, 3, 5]
   end
 
+  protected
+
+  def anything
+    [{ some: 'thing' }]
+  end
+
   private
 
   def left_side
@@ -36,7 +43,9 @@ class Baz
 
   # expecting:
   # {
-  #   foo: 4, bar: [1, 3, 5], nested: {
+  #   foo: 4, bar: [1, 3, 5],
+  #   anything: [{ some: 'thing' }],
+  #   nested: {
   #     left_side: 'left',
   #     right_side: true
   #   }
@@ -185,26 +194,24 @@ RSpec.describe Surrealist do
 
         it 'surrealizes' do
           expect(JSON.parse(instance.surrealize))
-            .to eq('foo' => 4, 'bar' => [1, 3, 5], 'nested' => {
-              'left_side'  => 'left',
-              'right_side' => true,
-            })
+            .to eq('foo' => 4, 'bar' => [1, 3, 5], 'anything' => [{ 'some' => 'thing' }],
+                   'nested' => { 'left_side'  => 'left', 'right_side' => true })
         end
 
         it 'builds schema' do
           expect(instance.build_schema)
-            .to eq(foo: 4, bar: [1, 3, 5], nested: { left_side: 'left', right_side: true })
+            .to eq(foo: 4, bar: [1, 3, 5], anything: [{ some: 'thing' }],
+                   nested: { left_side: 'left', right_side: true })
         end
 
         it 'camelizes' do
           expect(JSON.parse(instance.surrealize(camelize: true)))
-            .to eq('foo' => 4, 'bar' => [1, 3, 5], 'nested' => {
-              'leftSide'  => 'left',
-              'rightSide' => true,
-            })
+            .to eq('foo' => 4, 'bar' => [1, 3, 5], 'anything' => [{ 'some' => 'thing' }],
+                   'nested' => { 'leftSide'  => 'left', 'rightSide' => true })
 
           expect(instance.build_schema(camelize: true))
-            .to eq(foo: 4, bar: [1, 3, 5], nested: { leftSide: 'left', rightSide: true })
+            .to eq(foo: 4, bar: [1, 3, 5], anything: [{ some: 'thing' }],
+                   nested: { leftSide: 'left', rightSide: true })
         end
       end
 

--- a/surrealist.gemspec
+++ b/surrealist.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
Now one can be able to write:
```ruby
class User
  include Surrealist

  json_schema do
    { age: Any }
  end
end
```
And type checks will be skipped for `age`