### PR TITLE
Refactor Surrealist::Builder a bit

### DIFF
--- a/lib/surrealist/builder.rb
+++ b/lib/surrealist/builder.rb
@@ -62,12 +62,8 @@ module Surrealist
         object = instance.send(method)
 
         hash.each do |key, value|
-          if object.methods.include?(key)
-            take_values_from_instance(instance: object, value: value, hash: hash, key: key,
-                                      schema: schema, method: method)
-          else
-            call(schema: hash, instance: object)
-          end
+          take_values_from_instance(instance: object, value: value, hash: hash, key: key,
+                                    schema: schema, method: method)
         end
       end
 

--- a/spec/ultimate_spec.rb
+++ b/spec/ultimate_spec.rb
@@ -81,6 +81,34 @@ class Kid
   end
 end
 
+class WithWeirdSchema
+  include Surrealist
+
+  json_schema do
+    {
+      one: {
+        two: {
+          three: {
+            something: String,
+            level: {
+              deeper: {},
+              another: String,
+            },
+          },
+        },
+      },
+    }
+  end
+
+  def something
+    'a string'
+  end
+
+  def another
+    'another string'
+  end
+end
+
 RSpec.describe Surrealist do
   context 'ultimate spec' do
     let(:human) { Human.new('John', 'Doe') }
@@ -140,6 +168,15 @@ RSpec.describe Surrealist do
           creditCard: { cardNumber: 1234, cardHolder: 'John Doe' },
           children:   { male: { count: 2 }, female: { count: 1 } }
         })
+    end
+  end
+
+  context 'weird schema' do
+    it 'works' do
+      expect(WithWeirdSchema.new.build_schema)
+        .to eq(one: { two: { three: {
+          something: 'a string', level: { deeper: {}, another: 'another string' }
+        } } })
     end
   end
 end


### PR DESCRIPTION
Coverage report shows that this part of `Surrealist::Builder#maybe_take_values_from_instance` is not touched.
```ruby
if object.methods.include?(key)
  # actual code that is used
else
  call(schema: hash, instance: object) # useless
end
```
I think that tests now cover most of the cases that can be covered, so I guess we can feel safe deleting useless lines of code. Also I have added a spec for a weird schema definition.

@AlessandroMinali what do you think? 