### PR TITLE
Replace keyword arguments with hash parameters

### DIFF
--- a/lib/surrealist/carrier.rb
+++ b/lib/surrealist/carrier.rb
@@ -20,16 +20,16 @@ module Surrealist
     # @raise ArgumentError if types of arguments are wrong.
     #
     # @return [Carrier] self if type checks were passed.
-    def self.call(camelize:, include_root:, include_namespaces:, root:, namespaces_nesting_level:)
-      new(camelize, include_root, include_namespaces, root, namespaces_nesting_level).sanitize!
+    def self.call(**args)
+      new(args).sanitize!
     end
 
-    def initialize(camelize, include_root, include_namespaces, root, namespaces_nesting_level)
-      @camelize                 = camelize
-      @include_root             = include_root
-      @include_namespaces       = include_namespaces
-      @root                     = root
-      @namespaces_nesting_level = namespaces_nesting_level
+    def initialize(args)
+      @camelize                 = args.delete(:camelize) || false
+      @include_root             = args.delete(:include_root) || false
+      @include_namespaces       = args.delete(:include_namespaces) || false
+      @root                     = args.delete(:root) || nil
+      @namespaces_nesting_level = args.delete(:namespaces_nesting_level) || DEFAULT_NESTING_LEVEL
     end
 
     # Performs type checks

--- a/lib/surrealist/carrier.rb
+++ b/lib/surrealist/carrier.rb
@@ -24,7 +24,7 @@ module Surrealist
       new(args).sanitize!
     end
 
-    def initialize(args)
+    def initialize(**args)
       @camelize                 = args.delete(:camelize) || false
       @include_root             = args.delete(:include_root) || false
       @include_namespaces       = args.delete(:include_namespaces) || false

--- a/lib/surrealist/instance_methods.rb
+++ b/lib/surrealist/instance_methods.rb
@@ -48,27 +48,13 @@ module Surrealist
     #   User.new.surrealize
     #   # => "{\"name\":\"Nikita\",\"age\":23}"
     #   # For more examples see README
-    def surrealize(camelize: false, include_root: false, include_namespaces: false, root: nil, namespaces_nesting_level: DEFAULT_NESTING_LEVEL) # rubocop:disable Metrics/LineLength
-      JSON.dump(
-        build_schema(
-          camelize: camelize,
-          include_root: include_root,
-          include_namespaces: include_namespaces,
-          root: root,
-          namespaces_nesting_level: namespaces_nesting_level,
-        ),
-      )
+    def surrealize(**args)
+      JSON.dump(build_schema(args))
     end
 
     # Invokes +Surrealist+'s class method +build_schema+
-    def build_schema(camelize: false, include_root: false, include_namespaces: false, root: nil, namespaces_nesting_level: DEFAULT_NESTING_LEVEL) # rubocop:disable Metrics/LineLength
-      carrier = Surrealist::Carrier.call(
-        camelize: camelize,
-        include_namespaces: include_namespaces,
-        include_root: include_root,
-        root: root,
-        namespaces_nesting_level: namespaces_nesting_level,
-      )
+    def build_schema(**args)
+      carrier = Surrealist::Carrier.call(args)
 
       Surrealist.build_schema(instance: self, carrier: carrier)
     end


### PR DESCRIPTION
There are just too many of them to deal with. Additionally, `**args` are faster than kwargs.