### PR TITLE
fix failing serialization with sequel & custom serializer

### DIFF
--- a/lib/surrealist.rb
+++ b/lib/surrealist.rb
@@ -54,7 +54,7 @@ module Surrealist
     #   # => "[{\"name\":\"Nikita\",\"age\":23}, {\"name\":\"Alessandro\",\"age\":24}]"
     #   # For more examples see README
     def surrealize_collection(collection, **args)
-      Surrealist::ExceptionRaiser.raise_invalid_collection! unless collection.respond_to?(:each)
+      Surrealist::ExceptionRaiser.raise_invalid_collection! unless Helper.collection?(collection)
 
       result = collection.map do |object|
         Helper.surrealist?(object.class) ? __build_schema(object, args) : object

--- a/lib/surrealist/exception_raiser.rb
+++ b/lib/surrealist/exception_raiser.rb
@@ -31,7 +31,7 @@ module Surrealist
   # A class that raises all Surrealist exceptions
   module ExceptionRaiser
     CLASS_NAME_NOT_PASSED           = "Can't wrap schema in root key - class name was not passed".freeze
-    MUST_RESPOND_TO_EACH            = "Can't serialize collection - must respond to :each".freeze
+    MUST_BEHAVE_LIKE_ENUMERABLE     = "Can't serialize collection - must behave like enumerable".freeze
     CLASS_DOESNT_INCLUDE_SURREALIST = 'Class does not include Surrealist'.freeze
 
     class << self
@@ -64,7 +64,7 @@ module Surrealist
       #
       # @raise Surrealist::InvalidCollectionError
       def raise_invalid_collection!
-        raise Surrealist::InvalidCollectionError, MUST_RESPOND_TO_EACH
+        raise Surrealist::InvalidCollectionError, MUST_BEHAVE_LIKE_ENUMERABLE
       end
 
       # Raises ArgumentError if namespaces_nesting_level is not an integer.

--- a/lib/surrealist/helper.rb
+++ b/lib/surrealist/helper.rb
@@ -11,5 +11,17 @@ module Surrealist
     def self.surrealist?(klass)
       klass < Surrealist || klass < Surrealist::Serializer
     end
+
+    def self.collection?(object)
+      # 4.2 AR relation object did not include Enumerable (it defined
+      # all necessary method through ActiveRecord::Delegation module),
+      # so we need to explicitly check for this
+      object.is_a?(Enumerable) || ar_relation?(object)
+    end
+
+    def self.ar_relation?(object)
+      defined?(ActiveRecord) && object.is_a?(ActiveRecord::Relation)
+    end
+    private_class_method :ar_relation?
   end
 end

--- a/lib/surrealist/serializer.rb
+++ b/lib/surrealist/serializer.rb
@@ -41,7 +41,7 @@ module Surrealist
 
     # Checks whether object is a collection or an instance and serializes it
     def surrealize(**args)
-      if object.respond_to?(:each)
+      if Helper.collection?(object)
         Surrealist.surrealize_collection(object, args.merge(context: context))
       else
         Surrealist.surrealize(instance: self, **args)
@@ -50,7 +50,7 @@ module Surrealist
 
     # Passes build_schema to Surrealist
     def build_schema(**args)
-      if object.respond_to?(:each)
+      if Helper.collection?(object)
         build_collection_schema(args)
       else
         Surrealist.build_schema(instance: self, **args)

--- a/lib/surrealist/value_assigner.rb
+++ b/lib/surrealist/value_assigner.rb
@@ -18,7 +18,7 @@ module Surrealist
 
         if value.respond_to?(:build_schema)
           yield assign_nested_record(instance, value)
-        elsif value.respond_to?(:each) && !value.empty? && value.all? { |v| Helper.surrealist?(v.class) }
+        elsif Helper.collection?(value) && !value.empty? && value.all? { |v| Helper.surrealist?(v.class) }
           yield assign_nested_collection(instance, value)
         else
           yield value

--- a/spec/orms/active_record/active_record_spec.rb
+++ b/spec/orms/active_record/active_record_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'ActiveRecord integration' do
           it 'fails if scope returns a single record' do
             expect { Surrealist.surrealize_collection(lambda.call) }
               .to raise_error Surrealist::InvalidCollectionError,
-                              'Can\'t serialize collection - must respond to :each'
+                              'Can\'t serialize collection - must behave like enumerable'
           end
         end
       end
@@ -205,7 +205,7 @@ RSpec.describe 'ActiveRecord integration' do
       it 'fails' do
         expect { Surrealist.surrealize_collection(Object) }
           .to raise_error(Surrealist::InvalidCollectionError,
-                          'Can\'t serialize collection - must respond to :each')
+                          'Can\'t serialize collection - must behave like enumerable')
       end
     end
 

--- a/spec/orms/sequel/models.rb
+++ b/spec/orms/sequel/models.rb
@@ -67,6 +67,19 @@ class Song < Sequel::Model
   json_schema { { title: String } }
 end
 
+class ArtistSerializer < Surrealist::Serializer
+  json_schema { { name: String } }
+end
+
+class ArtistWithCustomSerializer < Sequel::Model(:artists)
+  include Surrealist
+
+  one_to_many :albums
+  many_to_many :songs
+
+  surrealize_with ArtistSerializer
+end
+
 7.times { |i| Artist.insert(name: "Artist #{i}", age: (18 + i * 4)) }
 
 Artist.each_with_index do |artist, i|

--- a/spec/orms/sequel/sequel_spec.rb
+++ b/spec/orms/sequel/sequel_spec.rb
@@ -293,4 +293,49 @@ RSpec.describe 'Sequel integration' do
       end
     end
   end
+
+  describe 'custom serializer' do
+    describe 'instances' do
+      context 'implicit usage' do
+        let(:instance) { ArtistWithCustomSerializer.first }
+        let(:subject) { instance.surrealize }
+
+        it { is_expected.to eq({ name: 'Artist 0' }.to_json) }
+        it_behaves_like 'error is not raised for valid params: instance'
+        it_behaves_like 'error is raised for invalid params: instance'
+      end
+
+      context 'explicit usage' do
+        let(:instance) { Artist.first }
+        let(:subject) { ArtistSerializer.new(instance).surrealize }
+
+        it { is_expected.to eq({ name: 'Artist 0' }.to_json) }
+        it_behaves_like 'error is not raised for valid params: instance'
+        it_behaves_like 'error is raised for invalid params: instance'
+      end
+    end
+
+    describe 'collections' do
+      let(:all) { Array.new(7) { |i| { name: "Artist #{i}" } } }
+      let(:serialized_collection) { all.to_json }
+
+      context 'implicit usage' do
+        let(:collection) { ArtistWithCustomSerializer.all }
+        let(:subject) { Surrealist.surrealize_collection(collection) }
+
+        it { is_expected.to eq(serialized_collection) }
+        it_behaves_like 'error is not raised for valid params: collection'
+        it_behaves_like 'error is raised for invalid params: collection'
+      end
+
+      context 'explicit usage' do
+        let(:collection) { Artist.all }
+        let(:subject) { ArtistSerializer.new(collection).surrealize }
+
+        it { is_expected.to eq(serialized_collection) }
+        it_behaves_like 'error is not raised for valid params: collection'
+        it_behaves_like 'error is raised for invalid params: collection'
+      end
+    end
+  end
 end


### PR DESCRIPTION
refactor checking whether object is a collection: move the check to
helper
use more strict version of a check: responding to `each` does not always
mean that object is a collection, but most of collections include
Enumerable
add explicit check for ActiveRecord::Relation - though it does not
include Enumerable in version 4.2, we still need to consider it a
collection
improve error message when collection does not fit these rules

Fixes #83