### PR TITLE
Benchmark fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development, :test do
   gem 'active_model_serializers', '~> 0.10.0'
   gem 'activerecord'
   gem 'benchmark-ips'
+  gem 'blueprinter'
   gem 'coveralls', require: false
   gem 'dry-struct'
   gem 'dry-types'

--- a/benchmarks/surrealist_vs_ams.rb
+++ b/benchmarks/surrealist_vs_ams.rb
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define do
   create_table :books do |table|
     table.column :title, :string
     table.column :year, :string
-    table.belongs_to :author
+    table.belongs_to :author, foreign_key: true
   end
 end
 
@@ -76,7 +76,7 @@ class Book < ActiveRecord::Base
   include Surrealist
   surrealize_with BookSurrealistSerializer
 
-  belongs_to :author
+  belongs_to :author, required: true
 end
 
 class AuthorSerializer < ActiveModel::Serializer
@@ -96,7 +96,7 @@ end
 N = 3000
 N.times { User.create!(name: random_name, email: "#{random_name}@test.com") }
 (N / 2).times { Author.create!(name: random_name, last_name: random_name, age: rand(80)) }
-N.times { Book.create!(title: random_name, year: "19#{rand(10..99)}", author_id: rand(1..N)) }
+N.times { Book.create!(title: random_name, year: "19#{rand(10..99)}", author_id: rand(1..N / 2)) }
 
 def benchmark_instance(ams_arg = '')
   user = User.find(rand(1..N))

--- a/benchmarks/surrealist_vs_ams.rb
+++ b/benchmarks/surrealist_vs_ams.rb
@@ -53,7 +53,11 @@ end
 
 class AuthorSurrealistSerializer < Surrealist::Serializer
   json_schema do
-    { name: String, last_name: String, full_name: String, age: Integer, books: Object }
+    { name: String, last_name: String, full_name: String, age: Integer, books: Array }
+  end
+
+  def books
+    object.books.to_a
   end
 
   def full_name

--- a/benchmarks/surrealist_vs_ams.rb
+++ b/benchmarks/surrealist_vs_ams.rb
@@ -130,13 +130,13 @@ def benchmark(names, serializers)
   end
 end
 
-def benchmark_instance(ams_arg = '')
+def benchmark_instance(ams_arg: '', am_arg: '')
   user = User.find(rand(1..N))
 
   names = ["AMS#{ams_arg}: instance",
            'Surrealist: instance through .surrealize',
            'Surrealist: instance through Surrealist::Serializer',
-           'ActiveModel::Serializers::JSON instance']
+           "ActiveModel::Serializers::JSON#{am_arg} instance"]
 
   serializers = [-> { UserAMSSerializer.new(user).to_json },
                  -> { user.surrealize },
@@ -146,13 +146,13 @@ def benchmark_instance(ams_arg = '')
   benchmark(names, serializers)
 end
 
-def benchmark_collection(ams_arg = '')
+def benchmark_collection(ams_arg: '', am_arg: '')
   users = User.all
 
   names = ["AMS#{ams_arg}: collection",
            'Surrealist: collection through Surrealist.surrealize_collection()',
            'Surrealist: collection through Surrealist::Serializer',
-           'ActiveModel::Serializers::JSON collection']
+           "ActiveModel::Serializers::JSON#{am_arg} collection"]
 
   serializers = [lambda do
                    ActiveModel::Serializer::CollectionSerializer.new(
@@ -218,8 +218,18 @@ benchmark_collection
 puts "\n------- Turning off AMS logger -------\n"
 ActiveModelSerializers.logger.level = Logger::Severity::UNKNOWN
 
-benchmark_instance('(without logging)')
-benchmark_collection('(without logging)')
+benchmark_instance(ams_arg: '(without logging)')
+benchmark_collection(ams_arg: '(without logging)')
+
+# Associations
+benchmark_associations_instance
+benchmark_associations_collection
+
+puts "\n------- Enabling Oj.optimize_rails() -------\n"
+Oj.optimize_rails
+
+benchmark_instance(ams_arg: '(without logging)', am_arg: '(with Oj)')
+benchmark_collection(ams_arg: '(without logging)', am_arg: '(with Oj)')
 
 # Associations
 benchmark_associations_instance


### PR DESCRIPTION
First commit fixes benchmark correctness (and asserts that different serializator results are the same), then adds `ActiveModel::Serializers::JSON` (i. e. default rails `#to_json`) to the mix, then adds results using [Oj.optimize_rails()](https://github.com/ohler55/oj/blob/master/pages/Rails.md).

<details>
<summary>Benchmark results (warming up removed)</summary>
<pre>
Calculating -------------------------------------
       AMS: instance     19.173k (±10.1%) i/s -     96.637k in   5.102175s
Surrealist: instance through .surrealize
                         27.553k (± 9.5%) i/s -    139.774k in   5.124042s
Surrealist: instance through Surrealist::Serializer
                         28.039k (± 8.1%) i/s -    140.196k in   5.035069s
ActiveModel::Serializers::JSON instance
                         15.139k (±10.5%) i/s -     74.970k in   5.008904s

Comparison:
Surrealist: instance through Surrealist::Serializer:    28038.8 i/s
Surrealist: instance through .surrealize:    27553.2 i/s - same-ish: difference falls within error
       AMS: instance:    19172.9 i/s - 1.46x  slower
ActiveModel::Serializers::JSON instance:    15139.0 i/s - 1.85x  slower

Calculating -------------------------------------
     AMS: collection      4.116  (± 0.0%) i/s -     21.000  in   5.135153s
Surrealist: collection through Surrealist.surrealize_collection()
                         12.114  (± 8.3%) i/s -     61.000  in   5.050207s
Surrealist: collection through Surrealist::Serializer
                         10.792  (± 0.0%) i/s -     54.000  in   5.011827s
ActiveModel::Serializers::JSON collection
                          8.456  (±11.8%) i/s -     43.000  in   5.119011s

Comparison:
Surrealist: collection through Surrealist.surrealize_collection():       12.1 i/s
Surrealist: collection through Surrealist::Serializer:       10.8 i/s - 1.12x  slower
ActiveModel::Serializers::JSON collection:        8.5 i/s - 1.43x  slower
     AMS: collection:        4.1 i/s - 2.94x  slower


------- Turning off AMS logger -------
Calculating -------------------------------------
AMS(without logging): instance
                         20.205k (± 5.5%) i/s -    101.592k in   5.043721s
Surrealist: instance through .surrealize
                         34.150k (± 5.1%) i/s -    172.091k in   5.053013s
Surrealist: instance through Surrealist::Serializer
                         29.779k (± 8.8%) i/s -    149.350k in   5.059733s
ActiveModel::Serializers::JSON instance
                         22.136k (± 6.5%) i/s -    112.148k in   5.089893s

Comparison:
Surrealist: instance through .surrealize:    34150.4 i/s
Surrealist: instance through Surrealist::Serializer:    29779.0 i/s - 1.15x  slower
ActiveModel::Serializers::JSON instance:    22136.0 i/s - 1.54x  slower
AMS(without logging): instance:    20205.1 i/s - 1.69x  slower

Calculating -------------------------------------
AMS(without logging): collection
                          4.131  (± 0.0%) i/s -     21.000  in   5.092559s
Surrealist: collection through Surrealist.surrealize_collection()
                         12.134  (± 8.2%) i/s -     61.000  in   5.041308s
Surrealist: collection through Surrealist::Serializer
                         10.123  (± 9.9%) i/s -     51.000  in   5.084796s
ActiveModel::Serializers::JSON collection
                          8.931  (± 0.0%) i/s -     45.000  in   5.052866s

Comparison:
Surrealist: collection through Surrealist.surrealize_collection():       12.1 i/s
Surrealist: collection through Surrealist::Serializer:       10.1 i/s - 1.20x  slower
ActiveModel::Serializers::JSON collection:        8.9 i/s - 1.36x  slower
AMS(without logging): collection:        4.1 i/s - 2.94x  slower

Calculating -------------------------------------
AMS (associations): instance
                          2.301k (± 3.9%) i/s -     11.664k in   5.076891s
Surrealist (associations): instance through .surrealize
                          3.494k (± 6.4%) i/s -     17.442k in   5.012614s
Surrealist (associations): instance through Surrealist::Serializer
                          3.527k (± 5.2%) i/s -     17.640k in   5.016124s
ActiveModel::Serializers::JSON (associations)
                          9.235k (± 4.1%) i/s -     46.176k in   5.008727s

Comparison:
ActiveModel::Serializers::JSON (associations):     9234.6 i/s
Surrealist (associations): instance through Surrealist::Serializer:     3526.7 i/s - 2.62x  slower
Surrealist (associations): instance through .surrealize:     3493.8 i/s - 2.64x  slower
AMS (associations): instance:     2301.1 i/s - 4.01x  slower

Calculating -------------------------------------
AMS (associations): collection
                          1.347  (± 0.0%) i/s -      7.000  in   5.222496s
Surrealist (associations): collection through Surrealist.surrealize_collection()
                          2.193  (± 0.0%) i/s -     11.000  in   5.034935s
Surrealist (associations): collection through Surrealist::Serializer
                          2.136  (± 0.0%) i/s -     11.000  in   5.171849s
ActiveModel::Serializers::JSON (associations): collection
                          6.738  (± 0.0%) i/s -     34.000  in   5.059023s

Comparison:
ActiveModel::Serializers::JSON (associations): collection:        6.7 i/s
Surrealist (associations): collection through Surrealist.surrealize_collection():        2.2 i/s - 3.07x  slower
Surrealist (associations): collection through Surrealist::Serializer:        2.1 i/s - 3.15x  slower
AMS (associations): collection:        1.3 i/s - 5.00x  slower


------- Enabling Oj.optimize_rails() -------
Calculating -------------------------------------
AMS(without logging): instance
                         40.399k (± 7.9%) i/s -    201.665k in   5.024492s
Surrealist: instance through .surrealize
                         34.852k (± 3.5%) i/s -    176.605k in   5.073404s
Surrealist: instance through Surrealist::Serializer
                         30.435k (± 5.0%) i/s -    151.792k in   5.000292s
ActiveModel::Serializers::JSON(with Oj) instance
                         37.683k (± 4.5%) i/s -    188.352k in   5.008880s

Comparison:
AMS(without logging): instance:    40398.8 i/s
ActiveModel::Serializers::JSON(with Oj) instance:    37683.4 i/s - same-ish: difference falls within error
Surrealist: instance through .surrealize:    34851.8 i/s - 1.16x  slower
Surrealist: instance through Surrealist::Serializer:    30435.2 i/s - 1.33x  slower

Calculating -------------------------------------
AMS(without logging): collection
                          7.715  (± 0.0%) i/s -     39.000  in   5.068282s
Surrealist: collection through Surrealist.surrealize_collection()
                         12.258  (± 8.2%) i/s -     62.000  in   5.078748s
Surrealist: collection through Surrealist::Serializer
                         10.770  (± 9.3%) i/s -     54.000  in   5.035842s
ActiveModel::Serializers::JSON(with Oj) collection
                         16.470  (± 6.1%) i/s -     83.000  in   5.065701s

Comparison:
ActiveModel::Serializers::JSON(with Oj) collection:       16.5 i/s
Surrealist: collection through Surrealist.surrealize_collection():       12.3 i/s - 1.34x  slower
Surrealist: collection through Surrealist::Serializer:       10.8 i/s - 1.53x  slower
AMS(without logging): collection:        7.7 i/s - 2.13x  slower

Calculating -------------------------------------
AMS (associations): instance
                          2.829k (± 4.9%) i/s -     14.364k in   5.090340s
Surrealist (associations): instance through .surrealize
                          3.568k (± 4.1%) i/s -     17.850k in   5.011707s
Surrealist (associations): instance through Surrealist::Serializer
                          3.549k (± 6.5%) i/s -     17.800k in   5.038607s
ActiveModel::Serializers::JSON (associations)
                         15.216k (± 6.5%) i/s -     76.479k in   5.047244s

Comparison:
ActiveModel::Serializers::JSON (associations):    15216.4 i/s
Surrealist (associations): instance through .surrealize:     3567.5 i/s - 4.27x  slower
Surrealist (associations): instance through Surrealist::Serializer:     3549.1 i/s - 4.29x  slower
AMS (associations): instance:     2828.6 i/s - 5.38x  slower

Calculating -------------------------------------
AMS (associations): collection
                          1.536  (± 0.0%) i/s -      8.000  in   5.223444s
Surrealist (associations): collection through Surrealist.surrealize_collection()
                          2.051  (± 0.0%) i/s -     11.000  in   5.393523s
Surrealist (associations): collection through Surrealist::Serializer
                          1.927  (± 0.0%) i/s -     10.000  in   5.250022s
ActiveModel::Serializers::JSON (associations): collection
                         11.287  (± 8.9%) i/s -     57.000  in   5.077676s
Comparison:
ActiveModel::Serializers::JSON (associations): collection:       11.3 i/s
Surrealist (associations): collection through Surrealist.surrealize_collection():        2.1 i/s - 5.50x  slower
Surrealist (associations): collection through Surrealist::Serializer:        1.9 i/s - 5.86x  slower
AMS (associations): collection:        1.5 i/s - 7.35x  slower
</pre>
</details>

Conditions was not ideal at all (laptop w/ web-browser and some other stuff opened), so I haven't updated results in the benchmark source.

Overall both Surrealist & AMS considerably slower than ActiveModel in serializing associations (I assume association serializer instance is created for each model instance) and ActiveModel are faster that both AMS & Surrealist after `Oj.optimize_rails()`.


- benchmark correctness check is quite ugly, so I will improve it if you have any suggestions
- benchmark filename isn't changed (what should I rename it to?)
- I could deduplicate/move to a method `Benchmark.ips` blocks if you want.