### PR TITLE
Allow hash surrealization

### DIFF
--- a/lib/surrealist/helper.rb
+++ b/lib/surrealist/helper.rb
@@ -16,7 +16,7 @@ module Surrealist
       # 4.2 AR relation object did not include Enumerable (it defined
       # all necessary method through ActiveRecord::Delegation module),
       # so we need to explicitly check for this
-      object.is_a?(Enumerable) || ar_relation?(object)
+      (object.is_a?(Enumerable) && !object.instance_of?(Hash)) || ar_relation?(object)
     end
 
     def self.ar_relation?(object)

--- a/lib/surrealist/serializer.rb
+++ b/lib/surrealist/serializer.rb
@@ -54,7 +54,7 @@ module Surrealist
     #   e.g `CatSerializer.new(Cat.new(3), food: CatFood.new)`
     #   And then food will be available inside serializer via `context[:food]`
     def initialize(object, **context)
-      @object = object
+      @object = wrap_hash_into_struct(object)
       @context = context
     end
 
@@ -93,6 +93,10 @@ module Surrealist
     # Methods not found inside serializer will be invoked on the object
     def respond_to_missing?(method, include_private = false)
       object.respond_to?(method) || super
+    end
+
+    def wrap_hash_into_struct(object)
+      object.instance_of?(Hash) ? OpenStruct.new(object) : object
     end
   end
 end

--- a/spec/build_schema_spec.rb
+++ b/spec/build_schema_spec.rb
@@ -158,8 +158,53 @@ class Chips < Potato
   # expecting: Surrealist::UnknownSchemaError
 end
 
+class ComplexNumber < Surrealist::Serializer
+  json_schema do
+    {
+      real: Integer,
+      imaginary: Integer,
+    }
+  end
+end
+
+class DeepHash < Surrealist::Serializer
+  json_schema do
+    {
+      list: Array,
+      nested: {
+        left: String,
+        right: Integer,
+      },
+    }
+  end
+end
+
+class HashRoot < Surrealist::Serializer
+  json_schema do
+    { nested: ComplexNumber.defined_schema }
+  end
+end
+
 RSpec.describe Surrealist do
   describe '#build_schema' do
+    context 'with hash arg' do
+      specify do
+        expect(ComplexNumber.new({real: 1, imaginary: 2}).build_schema).to eq(real: 1, imaginary: 2)
+      end
+    end
+
+    context 'deep hash arg' do
+      specify do
+        expect(DeepHash.new({list: [1, 2], nested: { right: 4, left: 'three'}}).build_schema).to eq({list: [1, 2], nested: { right: 4, left: 'three'}})
+      end
+    end
+
+    context 'root hash with object inside' do
+      specify do
+        expect(HashRoot.new({nested: OpenStruct.new(real: 1, imaginary: -1)}).build_schema).to eq({nested: { real: 1, imaginary: -1}})
+      end
+    end
+
     context 'with defined schema' do
       context 'with correct types' do
         it 'works' do

--- a/spec/build_schema_spec.rb
+++ b/spec/build_schema_spec.rb
@@ -189,19 +189,22 @@ RSpec.describe Surrealist do
   describe '#build_schema' do
     context 'with hash arg' do
       specify do
-        expect(ComplexNumber.new({real: 1, imaginary: 2}).build_schema).to eq(real: 1, imaginary: 2)
+        expect(ComplexNumber.new(real: 1, imaginary: 2).build_schema)
+          .to eq(real: 1, imaginary: 2)
       end
     end
 
     context 'deep hash arg' do
       specify do
-        expect(DeepHash.new({list: [1, 2], nested: { right: 4, left: 'three'}}).build_schema).to eq({list: [1, 2], nested: { right: 4, left: 'three'}})
+        expect(DeepHash.new(list: [1, 2], nested: { right: 4, left: 'three' }).build_schema)
+          .to eq(list: [1, 2], nested: { right: 4, left: 'three' })
       end
     end
 
     context 'root hash with object inside' do
       specify do
-        expect(HashRoot.new({nested: OpenStruct.new(real: 1, imaginary: -1)}).build_schema).to eq({nested: { real: 1, imaginary: -1}})
+        expect(HashRoot.new(nested: OpenStruct.new(real: 1, imaginary: -1)).build_schema)
+          .to eq(nested: { real: 1, imaginary: -1 })
       end
     end
 

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -157,14 +157,14 @@ RSpec.describe Surrealist::Serializer do
         let(:flour) { Struct.new(:amount).new(40) }
         let(:instance) { { color: 'yellow', amount: 60 } }
 
-        describe "#surrealize" do
+        describe '#surrealize' do
           subject(:json) { PancakeSerializer.new(instance, flour: flour).surrealize }
           let(:expectation) { { amount: 60, color: 'yellow' }.to_json }
 
           it { is_expected.to eq expectation }
         end
 
-        describe "#surrealize with include root" do
+        describe '#surrealize with include root' do
           subject(:json) { PancakeSerializer.new(instance, flour: flour).surrealize(include_root: true) }
           # NOTE: include root doesn't work as well when we call serializer in such way
           let(:expectation) { { pancake_serializer: { amount: 60, color: 'yellow' } }.to_json }
@@ -172,7 +172,7 @@ RSpec.describe Surrealist::Serializer do
           it { is_expected.to eq expectation }
         end
 
-        describe "#surrealize with camelize" do
+        describe '#surrealize with camelize' do
           let(:instance) { { name: 'Pepe' } }
           subject(:json) { DogeSerializer.new(instance, flour: flour).surrealize(camelize: true) }
           let(:expectation) { { name: 'Pepe', nameLength: 4 }.to_json }

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -151,6 +151,35 @@ RSpec.describe Surrealist::Serializer do
           it { is_expected.to eq expectation }
         end
       end
+
+      describe 'serializing hash' do
+        let(:milk) { Struct.new(:amount).new(20) }
+        let(:flour) { Struct.new(:amount).new(40) }
+        let(:instance) { { color: 'yellow', amount: 60 } }
+
+        describe "#surrealize" do
+          subject(:json) { PancakeSerializer.new(instance, flour: flour).surrealize }
+          let(:expectation) { { amount: 60, color: 'yellow' }.to_json }
+
+          it { is_expected.to eq expectation }
+        end
+
+        describe "#surrealize with include root" do
+          subject(:json) { PancakeSerializer.new(instance, flour: flour).surrealize(include_root: true) }
+          # NOTE: include root doesn't work as well when we call serializer in such way
+          let(:expectation) { { pancake_serializer: { amount: 60, color: 'yellow' } }.to_json }
+
+          it { is_expected.to eq expectation }
+        end
+
+        describe "#surrealize with camelize" do
+          let(:instance) { { name: 'Pepe' } }
+          subject(:json) { DogeSerializer.new(instance, flour: flour).surrealize(camelize: true) }
+          let(:expectation) { { name: 'Pepe', nameLength: 4 }.to_json }
+
+          it { is_expected.to eq expectation }
+        end
+      end
     end
 
     describe 'collection' do


### PR DESCRIPTION
Related issue: #96

Since version in master traverses hashes just fine when they're located deeper in object tree the issue with Hashes appears only when root object in a Hash. Instead of creating a HashBuilder for pure hashes, I tried to fix the existing process to allow surrealization of mixed data structures with Hash in the root.

Hash was misinterpreted as a collection by Helper#collection? and ValueAssigner#raw_value doesn't peek into instance's object while trying to extract value with Hash#[]. 
I tried to fix that in an ad-hoc manner, I hope it's not too bad. 
I think it would be better to rework value extraction in ValueAssigner, but I'm afraid value extraction logic can become too messy.

Anyway, I'm ready to discuss a better approach to resolve the issue.