### PR TITLE
Invoke parent serializer method instead of object method with the same name

### DIFF
--- a/lib/surrealist/serializer.rb
+++ b/lib/surrealist/serializer.rb
@@ -48,6 +48,26 @@ module Surrealist
 
       # Plural form ¯\_(ツ)_/¯
       alias serializer_contexts serializer_context
+
+      # Only lookup for methods defined in Surrealist::Serializer subclasses
+      #   to prevent invoke of Kernel methods
+      #
+      # @param [Symbol] method method to be invoked
+      #
+      # @return [Boolean]
+      def method_defined?(method)
+        return true if instance_methods(false).include?(method)
+        return false if superclass == Surrealist::Serializer
+
+        super
+      end
+
+      def private_method_defined?(method)
+        return true if private_instance_methods(false).include?(method)
+        return false if superclass == Surrealist::Serializer
+
+        super
+      end
     end
 
     # NOTE: #context will work only when using serializer explicitly,

--- a/lib/surrealist/value_assigner.rb
+++ b/lib/surrealist/value_assigner.rb
@@ -47,8 +47,8 @@ module Surrealist
       # @return [Object] the return value of the method
       def invoke_method(instance, method)
         object = instance.instance_variable_get(:@object)
-        instance_method = instance.class.instance_methods(false).include?(method) ||
-          instance.class.private_instance_methods(false).include?(method)
+        instance_method = instance.class.method_defined?(method) ||
+                          instance.class.private_method_defined?(method)
         invoke_object = !instance_method && object && object.respond_to?(method, true)
         invoke_object ? object.send(method) : instance.send(method)
       end

--- a/lib/surrealist/value_assigner.rb
+++ b/lib/surrealist/value_assigner.rb
@@ -77,6 +77,7 @@ module Surrealist
       # @return [Array] of schemas
       def assign_nested_collection(instance, value)
         return if @skip_set.include?(value.first.class)
+
         with_skip_set(instance.class) { Surrealist.surrealize_collection(value, raw: true) }
       end
 
@@ -88,6 +89,7 @@ module Surrealist
       # @return [Hash] schema
       def assign_nested_record(instance, value)
         return if @skip_set.include?(value.class)
+
         with_skip_set(instance.class) { value.build_schema }
       end
 
@@ -98,6 +100,7 @@ module Surrealist
       # @return [Object] block result
       def with_skip_set(klass)
         return yield if @skip_set.include?(klass)
+
         @skip_set.add(klass)
         result = yield
         @skip_set.delete(klass)

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -135,6 +135,12 @@ class FooSerializer < Surrealist::Serializer
   end
 end
 
+class FooChildSerializer < FooSerializer
+  json_schema do
+    { new_test: String, private_test: String }
+  end
+end
+
 RSpec.describe Surrealist::Serializer do
   describe 'Explicit surrealization through `Serializer.new`' do
     describe 'instance' do
@@ -356,6 +362,16 @@ RSpec.describe Surrealist::Serializer do
         expect(hash[:new_test]).to eq('serializer public method')
         expect(hash[:private_test]).to eq('serializer private method')
         expect(hash[:another_private]).to eq('model private method')
+      end
+
+      context 'when serializer inherited' do
+        let(:instance) { FooChildSerializer.new(model) }
+        let(:hash) { instance.build_schema }
+
+        it 'prefer parent serializer method before object method with the same name' do
+          expect(hash[:new_test]).to eq('serializer public method')
+          expect(hash[:private_test]).to eq('serializer private method')
+        end
       end
     end
   end


### PR DESCRIPTION
Fix #115 