### PR TITLE
Preserve exception backtrace in case of Surrealist::UndefinedMethodError

### DIFF
--- a/lib/surrealist/exception_raiser.rb
+++ b/lib/surrealist/exception_raiser.rb
@@ -90,7 +90,8 @@ module Surrealist
       def raise_invalid_key!(err)
         raise Surrealist::UndefinedMethodError,
               "#{err.message}. You have probably defined a key " \
-              "in the schema that doesn't have a corresponding method."
+              "in the schema that doesn't have a corresponding method.",
+              err.backtrace
       end
 
       # Raises ArgumentError if a tag has no corresponding serializer

--- a/spec/exception_raiser_spec.rb
+++ b/spec/exception_raiser_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Surrealist::ExceptionRaiser do
+  describe '.raise_invalid_key!' do
+    let(:backtrace) { %w[a b c] }
+
+    it 'preserves exception backtrace and displays correct message' do
+      begin
+        raise NoMethodError, 'my error message', backtrace
+      rescue NoMethodError => e
+        begin
+          described_class.raise_invalid_key!(e)
+        rescue Surrealist::UndefinedMethodError => e
+          expect(e.message).to eq(
+            "my error message. " \
+            "You have probably defined a key " \
+            "in the schema that doesn't have a corresponding method.",
+          )
+          expect(e.backtrace).to eq(backtrace)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Surrealist::UndefinedMethodError` rewrites exception backtrace, which makes it hard to debug this error.