### PR TITLE
Add a "Reviewed by Hound" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Inline docs](http://inch-ci.org/github/nesaulov/surrealist.svg?branch=master)](http://inch-ci.org/github/nesaulov/surrealist)
 [![Gem Version](https://badge.fury.io/rb/surrealist.svg)](https://rubygems.org/gems/surrealist)
 [![Open Source Helpers](https://www.codetriage.com/nesaulov/surrealist/badges/users.svg)](https://www.codetriage.com/nesaulov/surrealist)
+[![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
 ![Surrealist](surrealist-icon.png)
 


### PR DESCRIPTION
You should be able to fix the duplicate Hound status updates by going to [branch settings](https://github.com/nesaulov/surrealist/settings/branches) and unselecting `hound`. The capitalized version is the correct one.

<img width="748" alt="screenshot 2018-11-14 21 33 38" src="https://user-images.githubusercontent.com/154463/48532485-68a04c00-e855-11e8-83b9-2bcf60008123.png">

<img width="777" alt="screenshot 2018-11-14 21 33 16" src="https://user-images.githubusercontent.com/154463/48532484-68a04c00-e855-11e8-8a61-54e2a53d043a.png">