### PR TITLE
fix serialize Struct, now Struct is not a collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Inline docs](http://inch-ci.org/github/nesaulov/surrealist.svg?branch=master)](http://inch-ci.org/github/nesaulov/surrealist)
 [![Gem Version](https://badge.fury.io/rb/surrealist.svg)](https://rubygems.org/gems/surrealist)
 [![Open Source Helpers](https://www.codetriage.com/nesaulov/surrealist/badges/users.svg)](https://www.codetriage.com/nesaulov/surrealist)
+[![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
 ![Surrealist](surrealist-icon.png)
 

--- a/lib/surrealist/helper.rb
+++ b/lib/surrealist/helper.rb
@@ -16,7 +16,9 @@ module Surrealist
       # 4.2 AR relation object did not include Enumerable (it defined
       # all necessary method through ActiveRecord::Delegation module),
       # so we need to explicitly check for this
-      (object.is_a?(Enumerable) && !object.instance_of?(Hash)) || ar_relation?(object)
+      return false if object.is_a?(Struct)
+
+      object.is_a?(Enumerable) && !object.instance_of?(Hash) || ar_relation?(object)
     end
 
     def self.ar_relation?(object)

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Surrealist::Helper do
   describe 'serializing  a single struct' do
     let(:person) { TestStruct.new('John', 'Dow') }
 
-    it 'raise surrealize instead surrealize_collection with struct' do
+    specify 'a struct is not treated as a collection' do
       expect(Surrealist::Helper.collection?(person)).to eq false
     end
   end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+TestStruct = Struct.new(:name, :other_param)
+
+RSpec.describe Surrealist::Helper do
+  describe 'serializing  a single struct' do
+    let(:person) { TestStruct.new('John', 'Dow') }
+
+    it 'raise surrealize instead surrealize_collection with struct' do
+      expect(Surrealist::Helper.collection?(person)).to eq false
+    end
+  end
+end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -141,6 +141,12 @@ class FooChildSerializer < FooSerializer
   end
 end
 
+TestStruct = Struct.new(:name, :other_param)
+
+class TestStructSerializer < Surrealist::Serializer
+  json_schema { { name: String, other_param: String } }
+end
+
 RSpec.describe Surrealist::Serializer do
   describe 'Explicit surrealization through `Serializer.new`' do
     describe 'instance' do
@@ -210,6 +216,18 @@ RSpec.describe Surrealist::Serializer do
           it { is_expected.to eq expectation }
         end
       end
+
+      describe 'serialize Struct as single object' do
+        let(:person) { TestStruct.new('John', 'Dow') }
+        let(:expectation) { { name: 'John', other_param: 'Dow' } }
+        subject(:json) { TestStructSerializer.new(person).build_schema }
+
+        it { is_expected.to eq expectation }
+
+        it 'raise surrealize instead surrealize_collection with struct' do
+          expect(Surrealist::Helper.collection?(person)).to eq false
+        end
+      end
     end
 
     describe 'collection' do
@@ -250,6 +268,23 @@ RSpec.describe Surrealist::Serializer do
           it { is_expected.to eq expectation }
         end
       end
+    end
+
+    describe 'collection of Struct' do
+      let(:person1) { TestStruct.new('John', 'Dow') }
+      let(:person2) { TestStruct.new('Mountain', 'Dew') }
+      let(:person3) { TestStruct.new('Harley', 'Queen') }
+      let(:struct_collection) { [person1, person2, person3] }
+      let(:expectation) do
+        [
+          { name: 'John', other_param: 'Dow' },
+          { name: 'Mountain', other_param: 'Dew' },
+          { name: 'Harley', other_param: 'Queen' },
+        ]
+      end
+      subject(:json) { TestStructSerializer.new(struct_collection).build_schema }
+
+      it { is_expected.to eq expectation }
     end
   end
 

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -217,16 +217,12 @@ RSpec.describe Surrealist::Serializer do
         end
       end
 
-      describe 'serialize Struct as single object' do
+      describe 'serializing  a single struct' do
         let(:person) { TestStruct.new('John', 'Dow') }
         let(:expectation) { { name: 'John', other_param: 'Dow' } }
-        subject(:json) { TestStructSerializer.new(person).build_schema }
+        subject(:hash) { TestStructSerializer.new(person).build_schema }
 
         it { is_expected.to eq expectation }
-
-        it 'raise surrealize instead surrealize_collection with struct' do
-          expect(Surrealist::Helper.collection?(person)).to eq false
-        end
       end
     end
 
@@ -268,23 +264,24 @@ RSpec.describe Surrealist::Serializer do
           it { is_expected.to eq expectation }
         end
       end
-    end
 
-    describe 'collection of Struct' do
-      let(:person1) { TestStruct.new('John', 'Dow') }
-      let(:person2) { TestStruct.new('Mountain', 'Dew') }
-      let(:person3) { TestStruct.new('Harley', 'Queen') }
-      let(:struct_collection) { [person1, person2, person3] }
-      let(:expectation) do
-        [
-          { name: 'John', other_param: 'Dow' },
-          { name: 'Mountain', other_param: 'Dew' },
-          { name: 'Harley', other_param: 'Queen' },
-        ]
+      describe 'collection of structs' do
+        let(:person1) { TestStruct.new('John', 'Dow') }
+        let(:person2) { TestStruct.new('Mountain', 'Dew') }
+        let(:person3) { TestStruct.new('Harley', 'Queen') }
+        let(:struct_collection) { [person1, person2, person3] }
+        let(:expectation) do
+          [
+            { name: 'John', other_param: 'Dow' },
+            { name: 'Mountain', other_param: 'Dew' },
+            { name: 'Harley', other_param: 'Queen' },
+          ]
+        end
+
+        subject(:json) { TestStructSerializer.new(struct_collection).build_schema }
+
+        it { is_expected.to eq expectation }
       end
-      subject(:json) { TestStructSerializer.new(struct_collection).build_schema }
-
-      it { is_expected.to eq expectation }
     end
   end
 


### PR DESCRIPTION
Correction of behavior during serialization Struct. Now Struct is perceived as a single object, not a collection.