### PR TITLE
Performance and memory improvements

### DIFF
--- a/lib/surrealist/hash_utils.rb
+++ b/lib/surrealist/hash_utils.rb
@@ -12,10 +12,10 @@ module Surrealist
       #
       # @return [Hash] camelized hash.
       def camelize_hash(hash)
-        if hash.is_a?(Hash)
-          Hash[hash.map { |k, v| [camelize_key(k, false), camelize_hash(v)] }]
-        else
-          hash
+        return hash unless hash.is_a?(Hash)
+
+        hash.each_with_object({}) do |(k, v), obj|
+          obj[camelize_key(k, false)] = camelize_hash(v)
         end
       end
 

--- a/lib/surrealist/string_utils.rb
+++ b/lib/surrealist/string_utils.rb
@@ -19,11 +19,12 @@ module Surrealist
       #
       # @return [String] new underscored string.
       def underscore(string)
-        string.gsub(NAMESPACES_SEPARATOR, UNDERSCORE)
-          .gsub(DASH_REGEXP1, UNDERSCORE_SUBSTITUTE)
-          .gsub(DASH_REGEXP2, UNDERSCORE_SUBSTITUTE)
-          .tr(DASH, UNDERSCORE)
-          .downcase
+        dup = string.gsub(NAMESPACES_SEPARATOR, UNDERSCORE)
+        dup.gsub!(DASH_REGEXP1, UNDERSCORE_SUBSTITUTE)
+        dup.gsub!(DASH_REGEXP2, UNDERSCORE_SUBSTITUTE)
+        dup.tr!(DASH, UNDERSCORE)
+        dup.downcase!
+        dup
       end
 
       # Camelizes a string.

--- a/lib/surrealist/string_utils.rb
+++ b/lib/surrealist/string_utils.rb
@@ -73,7 +73,9 @@ module Surrealist
         Surrealist::ExceptionRaiser.raise_invalid_nesting!(nesting_level) unless nesting_level.positive?
 
         klass.split(NAMESPACES_SEPARATOR).last(nesting_level).reverse.inject({}) do |a, n|
-          camelize ? Hash[camelize(uncapitalize(n), false).to_sym => a] : Hash[underscore(n).to_sym => a]
+          key = (camelize ? camelize(uncapitalize(n), false) : underscore(n)).to_sym
+
+          { key => a }
         end
       end
 

--- a/lib/surrealist/string_utils.rb
+++ b/lib/surrealist/string_utils.rb
@@ -72,7 +72,7 @@ module Surrealist
       def break_namespaces(klass, camelize, nesting_level)
         Surrealist::ExceptionRaiser.raise_invalid_nesting!(nesting_level) unless nesting_level.positive?
 
-        klass.split(NAMESPACES_SEPARATOR).last(nesting_level).reverse.inject({}) do |a, n|
+        klass.split(NAMESPACES_SEPARATOR).last(nesting_level).reverse!.inject({}) do |a, n|
           key = (camelize ? camelize(uncapitalize(n), false) : underscore(n)).to_sym
 
           { key => a }

--- a/lib/surrealist/wrapper.rb
+++ b/lib/surrealist/wrapper.rb
@@ -60,7 +60,7 @@ module Surrealist
                    else
                      Surrealist::StringUtils.underscore(root).to_sym
                    end
-        result = Hash[root_key => {}]
+        result = { root_key => {} }
         Surrealist::Copier.deep_copy(schema, result[root_key])
 
         result


### PR DESCRIPTION
`hash.each_with_object` is faster and uses less memory than `Hash[hash.map]`
`gsub!` is faster and uses less memory than `gsub`
`{ key => value }` is faster and uses less memory than `Hash[key => value]`
`match?` is faster then `=~`