### PR TITLE
Fix serializing when direct instance method call returns nil

### DIFF
--- a/lib/surrealist/builder.rb
+++ b/lib/surrealist/builder.rb
@@ -4,7 +4,8 @@ module Surrealist
   # A class that builds a hash from the schema and type-checks the values.
   class Builder
     # Struct to carry schema along
-    Schema = Struct.new(:key, :value).freeze
+    Schema = Struct.new(:key, :value)
+    Schema.freeze
 
     # @param [Carrier] carrier instance of Surrealist::Carrier
     # @param [Hash] schema the schema defined in the object's class.

--- a/lib/surrealist/serializer.rb
+++ b/lib/surrealist/serializer.rb
@@ -107,7 +107,9 @@ module Surrealist
 
     # Methods not found inside serializer will be invoked on the object
     def method_missing(method, *args, &block)
-      object.public_send(method, *args, &block) || super
+      return super unless object.respond_to?(method)
+
+      object.public_send(method, *args, &block)
     end
 
     # Methods not found inside serializer will be invoked on the object

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -147,6 +147,14 @@ class TestStructSerializer < Surrealist::Serializer
   json_schema { { name: String, other_param: String } }
 end
 
+class AliasSerializer < Surrealist::Serializer
+  json_schema { { param: String } }
+
+  def param
+    other_param
+  end
+end
+
 RSpec.describe Surrealist::Serializer do
   describe 'Explicit surrealization through `Serializer.new`' do
     describe 'instance' do
@@ -217,10 +225,18 @@ RSpec.describe Surrealist::Serializer do
         end
       end
 
-      describe 'serializing  a single struct' do
+      describe 'serializing a single struct' do
         let(:person) { TestStruct.new('John', 'Dow') }
         let(:expectation) { { name: 'John', other_param: 'Dow' } }
         subject(:hash) { TestStructSerializer.new(person).build_schema }
+
+        it { is_expected.to eq expectation }
+      end
+
+      describe 'serializing when direct instance method call returns nil' do
+        let(:person) { TestStruct.new('John', nil) }
+        let(:expectation) { { param: nil } }
+        subject(:hash) { AliasSerializer.new(person).build_schema }
 
         it { is_expected.to eq expectation }
       end


### PR DESCRIPTION
Fixing the following bug

```
class Test
  def returning_nil
    nil
  end
end

class Serializer < Surrealist::Serializer
  json_schema { { result: Integer } }

  def result
    returning_nil || 0
  end
end

Serializer.new(Test.new).build_schema
# NameError: undefined local variable or method `returning_nil' for #<Serializer:0x00007ffd708d19c0>
# from .../lib/surrealist/serializer.rb:110:in `method_missing'
```
