### PR TITLE
Make sure to splat out arguments for Ruby 3 required kwargs syntax

### DIFF
--- a/lib/surrealist.rb
+++ b/lib/surrealist.rb
@@ -131,7 +131,7 @@ module Surrealist
       parameters = config ? config.merge(args) : args
 
       # TODO: Refactor (something pipeline-like would do here, perhaps a builder of some sort)
-      carrier = Surrealist::Carrier.call(parameters)
+      carrier = Surrealist::Carrier.call(**parameters)
       copied_schema = Surrealist::Copier.deep_copy(schema)
       built_schema = Builder.new(carrier, copied_schema, instance).call
       wrapped_schema = Surrealist::Wrapper.wrap(built_schema, carrier, instance.class.name)

--- a/lib/surrealist/carrier.rb
+++ b/lib/surrealist/carrier.rb
@@ -22,7 +22,7 @@ module Surrealist
     #
     # @return [Carrier] self if type checks were passed.
     def self.call(**args)
-      new(args).sanitize!
+      new(**args).sanitize!
     end
 
     def initialize(**args)


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/